### PR TITLE
Loading freenas ui instead of nextcloud when vnet=off fixed.

### DIFF
--- a/configs/nextcloud.conf
+++ b/configs/nextcloud.conf
@@ -1,10 +1,10 @@
-<VirtualHost *:80>
+<VirtualHost bindapacheto:80>
  DocumentRoot "/usr/local/www/apache24/data/nextcloud"
  ServerName yourhostnamehere
  Redirect / https://yourhostnamehere/
 </VirtualHost>
 
-<VirtualHost *:443>
+<VirtualHost bindapacheto:443>
   ServerAdmin admin@example.com
   ServerName yourhostnamehere
   DocumentRoot "/usr/local/www/apache24/data/nextcloud"

--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -140,6 +140,11 @@ iocage exec ${JAIL_NAME} cp -f /mnt/configs/001_mod_php.conf /usr/local/etc/apac
 iocage exec ${JAIL_NAME} cp -f /mnt/configs/nextcloud.conf /usr/local/etc/apache24/Includes/${HOST_NAME}.conf
 iocage exec ${JAIL_NAME} cp -f /mnt/configs/www.conf /usr/local/etc/php-fpm.d/
 iocage exec ${JAIL_NAME} cp -f /usr/local/share/mysql/my-small.cnf /var/db/mysql/my.cnf
+if [ $VNET -eq on ]; then
+  iocage exec ${JAIL_NAME} sed -i '' "s/bindapacheto/*/" /usr/local/etc/apache24/Includes/${HOST_NAME}.conf
+else
+  iocage exec ${JAIL_NAME} sed -i '' "s/bindapacheto/${HOST_NAME}/" /usr/local/etc/apache24/Includes/${HOST_NAME}.conf
+fi
 iocage exec ${JAIL_NAME} sed -i '' "s/yourhostnamehere/${HOST_NAME}/" /usr/local/etc/apache24/Includes/${HOST_NAME}.conf
 iocage exec ${JAIL_NAME} sed -i '' "s/yourhostnamehere/${HOST_NAME}/" /usr/local/etc/apache24/httpd.conf
 iocage exec ${JAIL_NAME} sed -i '' "s/#skip-networking/skip-networking/" /var/db/mysql/my.cnf


### PR DESCRIPTION
When using the same network interface as freenas itself this will bind the virtualhost to the domain name.