### PR TITLE
Don't install apache24 pkg

### DIFF
--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -88,7 +88,7 @@ fi
 cat <<__EOF__ >/tmp/pkg.json
 {
   "pkgs":[
-  "nano","curl","sudo","apache24","mariadb101-server","redis","php72-ctype",
+  "nano","curl","sudo","mariadb101-server","redis","php72-ctype",
   "php72-dom","php72-gd","php72-iconv","php72-json","php72-mbstring",
   "php72-posix","php72-simplexml","php72-xmlreader","php72-xmlwriter",
   "php72-zip","php72-zlib","php72-pdo_mysql","php72-hash","php72-xml",


### PR DESCRIPTION
Inadvertently included apache24 in packages to install.  We're installing from ports instead, as the package has several vulnerabilities