### PR TITLE
Move .well-known out of nextcloud

### DIFF
--- a/configs/nextcloud.conf
+++ b/configs/nextcloud.conf
@@ -15,6 +15,12 @@
   <FilesMatch \.php$>
          SetHandler "proxy:fcgi://localhost:9000"
   </FilesMatch>
+  Alias /.well-known/acme-challenge/ "/usr/local/www/apache24/data/.well-known/acme-challenge/"
+  <Directory "/usr/local/www/apache24/data/.well-known">
+    AllowOverride None
+    Options MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec
+    Require method GET POST OPTIONS
+  </Directory>
   DirectoryIndex /index.php index.php
   SSLCertificateFile /usr/local/etc/pki/tls/certs/fullchain.pem
   SSLCertificateKeyFile /usr/local/etc/pki/tls/private/privkey.pem

--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -182,7 +182,7 @@ iocage exec ${JAIL_NAME} echo "Nextcloud Administrator password is ${ADMIN_PASSW
 
 # If standalone mode was used to issue certificate, reissue using webroot
 if [ $STANDALONE_CERT -eq 1 ]; then
-  iocage exec ${JAIL_NAME} /root/.acme.sh/acme.sh --issue ${TEST_CERT} --home "/root/.acme.sh" -d ${HOST_NAME} -w /usr/local/www/apache24/data/nextcloud -k 4096 --fullchain-file /usr/local/etc/pki/tls/certs/fullchain.pem --key-file /usr/local/etc/pki/tls/private/privkey.pem --reloadcmd "service apache24 reload"
+  iocage exec ${JAIL_NAME} /root/.acme.sh/acme.sh --issue ${TEST_CERT} --home "/root/.acme.sh" -d ${HOST_NAME} -w /usr/local/www/apache24/data -k 4096 --fullchain-file /usr/local/etc/pki/tls/certs/fullchain.pem --key-file /usr/local/etc/pki/tls/private/privkey.pem --reloadcmd "service apache24 reload"
 fi
 
 # CLI installation and configuration of Nextcloud


### PR DESCRIPTION
Add an alias to the virtual host so that the .well-known/acme-challenge/ path is found in /usr/local/www/apache24/data rather than in the nextcloud subdirectory.