### PR TITLE
Set recommended transaction isolation for mariadb

### DIFF
--- a/configs/my.cnf
+++ b/configs/my.cnf
@@ -1,3 +1,7 @@
 # MySQL client config file
 [client]
 password=mypassword
+
+[mysqld]
+transaction_isolation = READ-COMMITTED
+binlog_format = ROW

--- a/configs/my.cnf
+++ b/configs/my.cnf
@@ -1,7 +1,3 @@
 # MySQL client config file
 [client]
 password=mypassword
-
-[mysqld]
-transaction_isolation = READ-COMMITTED
-binlog_format = ROW

--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -227,6 +227,9 @@ iocage exec ${JAIL_NAME} cp -f /mnt/configs/www.conf /usr/local/etc/php-fpm.d/
 if [ "${DATABASE}" = "mariadb" ]; then
   iocage exec ${JAIL_NAME} cp -f /usr/local/share/mysql/my-small.cnf /var/db/mysql/my.cnf
   iocage exec ${JAIL_NAME} sed -i '' "s/#skip-networking/skip-networking/" /var/db/mysql/my.cnf
+  iocage exec ${JAIL_NAME} sed -i '' "/\[mysqld\]/i \
+transaction_isolation = READ-COMMITTED\
+binlog_format = ROW" /var/db/mysql/my.cnf
 fi
 iocage exec ${JAIL_NAME} sed -i '' "s/yourhostnamehere/${HOST_NAME}/" /usr/local/etc/apache24/Includes/${HOST_NAME}.conf
 iocage exec ${JAIL_NAME} sed -i '' "s/jailiphere/${JAIL_IP}/" /usr/local/etc/apache24/Includes/${HOST_NAME}.conf


### PR DESCRIPTION
See https://github.com/nextcloud/documentation/blob/master/admin_manual/configuration_database/linux_database_configuration.rst#database-read-committed-transaction-isolation-level