### PR TITLE
Add regex to remove version appendix

### DIFF
--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -41,7 +41,7 @@ elif [ "${DATABASE}" = "pgsql" ]; then
 fi
 
 ADMIN_PASSWORD=$(openssl rand -base64 12)
-RELEASE=$(freebsd-version | sed "s/STABLE/RELEASE/g")
+RELEASE=$(freebsd-version | sed "s/STABLE/RELEASE/g" | sed "s/-p[0-9]*//")
 
 # Check for nextcloud-config and set configuration
 if ! [ -e "${SCRIPTPATH}"/nextcloud-config ]; then


### PR DESCRIPTION
This is just an improvised fix to get the script working with the recent 11.3 release, where appearently no appendix is used (yet?). Fetching the OS version for the jail fails due to the unknown appendix used. This fix only considered working if you run 11.3-RELEASE.
More investigation is needed to solve this issue properly. Please don't merge.