### PR TITLE
Config default bugfix, Tweaks and Reinstall option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,20 @@ This script works best when your installation is able to obtain a certificate fr
 If you aren't able or willing to obtain a certificate from Let's Encrypt, this script also supports configuring Caddy with a self-signed certificate, or with no certificate (and thus no HTTPS) at all.
 
 ### Prerequisites (Other)
-Although not required, it's recommended to create two datasets on your main storage pool: one named `files`, which will store the Nextcloud user data; and one called `db`, which will store the SQL database.  For optimal performance, set the record size of the `db` dataset to 16 KB (under Advanced Settings in the FreeNAS web GUI).  It's also recommended to cache only metadata on the `db` dataset; you can do this by running `zfs set primarycache=metadata poolname/db`.
+There are Three options when it comes to datasets and folder structure:
+- 1 Dataset with subfolders
+- 1 Dataset with 4 sub-datasets
+- 4 Datasets
+
+Although not required, it's recommended to create 1 Dataset with 4 sub-datasets on your main storage pool
+- 1 Dataset named `nextcloud`
+Under which you create 4 other datasets
+- one named `files`, which will store the Nextcloud user data.
+- one named `config`, which will store the Nextcloud configuration.
+- one named `themes`, which will store the Nextcloud themes.
+- one called `db`, which will store the SQL database.  For optimal performance, set the record size of the `db` dataset to 16 KB (under Advanced Settings in the FreeNAS web GUI).  It's also recommended to cache only metadata on the `db` dataset; you can do this by running `zfs set primarycache=metadata poolname/db`.
+
+If you use 1 dataset with subfolders it's recomended to use a similair structure.
 
 ### Installation
 Download the repository to a convenient directory on your FreeNAS system by running `git clone https://github.com/danb35/freenas-iocage-nextcloud`.  Then change into the new directory and create a file called `nextcloud-config`.  It should look like this:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Many of the options are self-explanatory, and all should be adjusted to suit you
 In addition, there are some other options which have sensible defaults, but can be adjusted if needed.  These are:
 
 * JAIL_NAME: The name of the jail, defaults to "nextcloud"
-* DB_PATH, FILES_PATH, CONFIG_PATH and PORTS_PATH: These are the paths to your database files, your data files, nextcloud config (www/nextcloud/config) files and the FreeBSD Ports collection.  They default to $POOL_PATH/nextcloud/db, $POOL_PATH/nextcloud/files, $POOL_PATH/nextcloud/config and $POOL_PATH/portsnap, respectively.
+* DB_PATH, FILES_PATH, CONFIG_PATH, THEMES_PATH and PORTS_PATH: These are the paths to your database files, your data files, nextcloud config files, theme files and the FreeBSD Ports collection.  They default to $POOL_PATH/nextcloud/db, $POOL_PATH/nextcloud/files, $POOL_PATH/nextcloud/config, $POOL_PATH/nextcloud/themes and $POOL_PATH/portsnap, respectively.
 * DATABASE: Which database management system to use.  Default is "mariadb", but can be set to "pgsql" if you prefer to use PostgreSQL.
 * INTERFACE: The network interface to use for the jail.  Defaults to `vnet0`.
 * VNET: Whether to use the iocage virtual network stack.  Defaults to `on`.

--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -145,6 +145,7 @@ then
   echo "DB_PATH, FILES_PATH, CONFIG_PATH and PORTS_PATH must all be different!"
   exit 1
 elif [ "${THEMES_PATH}" = "${THEMES_PATH}" ] || [ "${THEMES_PATH}" = "${PORTS_PATH}" ] || [ "${THEMES_PATH}" = "${DB_PATH}" ] || [ "${THEMES_PATH}" = "${CONFIG_PATH}" ]
+then
   echo "DB_PATH, FILES_PATH, CONFIG_PATH, THEMES_PATH and PORTS_PATH must all be different!"
   exit 1
 fi

--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -145,14 +145,13 @@ then
   echo "DB_PATH, FILES_PATH, CONFIG_PATH and PORTS_PATH must all be different!"
   exit 1
 elif [ "${THEMES_PATH}" = "${THEMES_PATH}" ] || [ "${THEMES_PATH}" = "${PORTS_PATH}" ] || [ "${THEMES_PATH}" = "${DB_PATH}" ] || [ "${THEMES_PATH}" = "${CONFIG_PATH}" ]
-  echo "DB_PATH, FILES_PATH, CONFIG_PATH and PORTS_PATH must all be different!"
+  echo "DB_PATH, FILES_PATH, CONFIG_PATH, THEMES_PATH and PORTS_PATH must all be different!"
   exit 1
 fi
 
 if [ "${DB_PATH}" = "${POOL_PATH}" ] || [ "${FILES_PATH}" = "${POOL_PATH}" ] || [ "${PORTS_PATH}" = "${POOL_PATH}" ] || [ "${CONFIG_PATH}" = "${POOL_PATH}" ] || [ "${THEMES_PATH}" = "${POOL_PATH}" ]
 then
-  echo "DB_PATH, FILES_PATH, and PORTS_PATH must all be different"
-  echo "from POOL_PATH!"
+  echo "DB_PATH, FILES_PATH, CONFIG_PATH, THEMES_PATH and PORTS_PATH must all be different from POOL_PATH!"
   exit 1
 fi
 
@@ -231,7 +230,7 @@ iocage fstab -a "${JAIL_NAME}" "${PORTS_PATH}"/ports /usr/ports nullfs rw 0 0
 iocage fstab -a "${JAIL_NAME}" "${PORTS_PATH}"/db /var/db/portsnap nullfs rw 0 0
 iocage fstab -a "${JAIL_NAME}" "${FILES_PATH}" /mnt/files nullfs rw 0 0
 iocage fstab -a "${JAIL_NAME}" "${CONFIG_PATH}" /usr/local/www/nextcloud/config nullfs rw 0 0
-iocage fstab -a "${JAIL_NAME}" "${CONFIG_PATH}" /usr/local/www/nextcloud/themes nullfs rw 0 0
+iocage fstab -a "${JAIL_NAME}" "${THEMES_PATH}" /usr/local/www/nextcloud/themes nullfs rw 0 0
 if [ "${DATABASE}" = "mariadb" ]; then
   mkdir -p "${JAILS_MOUNT}"/jails/${JAIL_NAME}/root/var/db/mysql
   iocage fstab -a "${JAIL_NAME}" "${DB_PATH}/mariadb"  /var/db/mysql  nullfs  rw  0  0

--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -440,9 +440,9 @@ iocage fstab -r "${JAIL_NAME}" "${INCLUDES_PATH}" /mnt/includes nullfs rw 0 0
 # Done!
 echo "Installation complete!"
 if [ $NO_CERT -eq 1 ]; then
-  echo "Using your web browser, go to http://${nextcloud_host_name} to log in"
+  echo "Using your web browser, go to http://${${HOST_NAME}} to log in"
 else
-  echo "Using your web browser, go to https://${nextcloud_host_name} to log in"
+  echo "Using your web browser, go to https://${${HOST_NAME}} to log in"
 fi
 
 if [ "${REINSTALL}" == "true" ]; then

--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -353,6 +353,10 @@ iocage exec "${JAIL_NAME}" chown www /var/log/nextcloud.log
 # Skip generation of config and database for reinstall (this already exists when doing a reinstall)
 if [ "${REINSTALL}" == "true" ]; then
 	echo "Reinstall detected, skipping generaion of new config and database"
+	if [ "${DATABASE}" = "mariadb" ]; then
+	iocage exec "${JAIL_NAME}" cp -f /mnt/includes/my.cnf /root/.my.cnf
+	iocage exec "${JAIL_NAME}" sed -i '' "s|mypassword|${DB_ROOT_PASSWORD}|" /root/.my.cnf
+	fi
 else
 
 # Secure database, set root password, create Nextcloud DB, user, and password

--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -144,7 +144,7 @@ if [ "${DB_PATH}" = "${FILES_PATH}" ] || [ "${FILES_PATH}" = "${PORTS_PATH}" ] |
 then
   echo "DB_PATH, FILES_PATH, CONFIG_PATH and PORTS_PATH must all be different!"
   exit 1
-elif [ "${THEMES_PATH}" = "${THEMES_PATH}" ] || [ "${THEMES_PATH}" = "${PORTS_PATH}" ] || [ "${THEMES_PATH}" = "${DB_PATH}" ] || [ "${THEMES_PATH}" = "${CONFIG_PATH}" ]
+elif [ "${THEMES_PATH}" = "${PORTS_PATH}" ] || [ "${THEMES_PATH}" = "${DB_PATH}" ] || [ "${THEMES_PATH}" = "${CONFIG_PATH}" ]
 then
   echo "DB_PATH, FILES_PATH, CONFIG_PATH, THEMES_PATH and PORTS_PATH must all be different!"
   exit 1


### PR DESCRIPTION
This PR covers a number of changes:
- Added reinstall option (if config and DB are already present)
- Renamed mariadb mountpoint folder
- Fixed bug in config folder default
- Added "themes folder" mountpoint
- Splitting nextcloud download + webserver config from from nextcloud install chapter
- Explaining the new folder structure in the Readme
- Create in-code chapter for results output

**Notes:**
**Added reinstall option (if config and DB are already present)**
The reinstall automatically triggers if an existing config is detected, no users intervention or variable is required. It also checks of a compatible database as the one set in the variable is detected and only continues if BOTH are true.

**Renamed mariadb mountpoint folder**
Uniformity is important, the only place where mysql should be refered is the (odd, legacy) /var/db/mysql reference. renaming it to mariadb makes it play well with existing variables and the reinstall checks.

**Fixed bug in config folder default**
I fucked up and looked over setting the default for the config folder. this should NOT set the files folder, which could corrupt the whole install. Fixed here

**Added "themes folder" mountpoint**
To do a reinstall (or any form of saving config/data on external datasets), we should follow the Nextcloud backup guidelines:
https://docs.nextcloud.com/server/stable/admin_manual/maintenance/backup.html?highlight=backup

Those dictate that we should also make a mountpoint for the themes folder, which I did.

**Splitting nextcloud download + webserver config from from nextcloud install chapter**
It seems this was already pretty well seperated in code.
The reason to add a chapter marker is the following:
The only difference between an install and a reinstall of Nextcloud, is the fact that database and nextcloud config scripts/commands aren't called. Adding a chapter makers to seperate config of databases and nextcloud, creates clearity when developers read the reinstall if statement located there.

**Explaining the new folder structure in the Readme**
It seems I forgot to explain the new folder structure (including the new default nextcloud parent dataset) in the readme. This fixes that and also adds instructions for the new themes sub-dataset

**Create in-code chapter for results output**
The added reinstall option adds some logic to the console output, which makes it worthwhile giving it a clear chapter tag.