### PR TITLE
Add jail interfaces option to link vnet to different bridge

### DIFF
--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -16,6 +16,7 @@ fi
 
 # Initialize defaults
 JAIL_IP=""
+JAIL_INTERFACES=""
 DEFAULT_GW_IP=""
 INTERFACE="vnet0"
 VNET="on"
@@ -69,6 +70,10 @@ fi
 if [ -z "${JAIL_IP}" ]; then
   echo 'Configuration error: JAIL_IP must be set'
   exit 1
+fi
+if [ -z "${JAIL_INTERFACES}" ]; then
+  echo 'JAIL_INTERFACES not set, defaulting to: vnet0:bridge0'
+  JAIL_INTERFACES="vnet0:bridge0"
 fi
 if [ -z "${DEFAULT_GW_IP}" ]; then
   echo 'Configuration error: DEFAULT_GW_IP must be set'
@@ -174,7 +179,7 @@ cat <<__EOF__ >/tmp/pkg.json
 __EOF__
 
 # Create the jail and install previously listed packages
-if ! iocage create --name "${JAIL_NAME}" -p /tmp/pkg.json -r "${RELEASE}" ip4_addr="${INTERFACE}|${JAIL_IP}/24" defaultrouter="${DEFAULT_GW_IP}" boot="on" host_hostname="${JAIL_NAME}" vnet="${VNET}"
+if ! iocage create --name "${JAIL_NAME}" -p /tmp/pkg.json -r "${RELEASE}" interfaces="${JAIL_INTERFACES}" ip4_addr="${INTERFACE}|${JAIL_IP}/24" defaultrouter="${DEFAULT_GW_IP}" boot="on" host_hostname="${JAIL_NAME}" vnet="${VNET}"
 then
 	echo "Failed to create jail"
 	exit 1


### PR DESCRIPTION
This is a very small fix, that adds the option to set the (barely documented) "Interfaces" flag in iocage.
This flag makes it possible to link VNETs to different bridges.

In practice this means one can route route the default VNET0, to a different bridge thats linked to a different VLAN, like this: vnet0:bridge99

For more info how this would work in practice, see the jails and vlans guide from Lawrence systems available here:
https://www.youtube.com/watch?v=l6OsF5ppQnU&t=588s

This fixes #92