### PR TITLE
Spinning disc on login. Cannot login on mobile app.

### DIFF
--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -369,6 +369,8 @@ iocage exec "${JAIL_NAME}" su -m www -c 'php /usr/local/www/nextcloud/occ config
 iocage exec "${JAIL_NAME}" su -m www -c 'php /usr/local/www/nextcloud/occ config:system:set redis host --value="/tmp/redis.sock"'
 iocage exec "${JAIL_NAME}" su -m www -c 'php /usr/local/www/nextcloud/occ config:system:set redis port --value=0 --type=integer'
 iocage exec "${JAIL_NAME}" su -m www -c 'php /usr/local/www/nextcloud/occ config:system:set memcache.locking --value="\OC\Memcache\Redis"'
+iocage exec "${JAIL_NAME}" su -m www -c "php /usr/local/www/nextcloud/occ config:system:set overwritehost --value=\"${HOST_NAME}\""
+iocage exec "${JAIL_NAME}" su -m www -c "php /usr/local/www/nextcloud/occ config:system:set overwriteprotocol --value=\"https\""
 if [ $NO_CERT -eq 1 ]; then
   iocage exec "${JAIL_NAME}" su -m www -c "php /usr/local/www/nextcloud/occ config:system:set overwrite.cli.url --value=\"http://${HOST_NAME}/\""
 else


### PR DESCRIPTION
Hello danb35,

**Symptoms:**

Using Google Chrome or Microsoft Edge to login to Nextcloud results in a spinning disc. A screen refresh is required to get past the login screen. This issue does not arise with Mozilla Firefox. A more serious issue is that a refresh is not possible with the Nextcloud mobile app (tested on Android only) so login is not possible.

**The Cause**

The reason is described in this issue [Redirecting bug since 15.0.2](https://github.com/nextcloud/server/issues/13713). I believe it has something to do with being behind a reverse proxy.

