### PR TITLE
Fix mariadb access denied bug

### DIFF
--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -369,7 +369,7 @@ if [ "${DATABASE}" = "mariadb" ]; then
   iocage exec "${JAIL_NAME}" mysql -u root -e "DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');"
   iocage exec "${JAIL_NAME}" mysql -u root -e "DROP DATABASE IF EXISTS test;"
   iocage exec "${JAIL_NAME}" mysql -u root -e "DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';"
-  iocage exec "${JAIL_NAME}" mysql -u root -e "UPDATE mysql.user SET Password=PASSWORD('${DB_ROOT_PASSWORD}') WHERE User='root';"
+  iocage exec "${JAIL_NAME}" mysqladmin --user=root password "${DB_ROOT_PASSWORD}"
   iocage exec "${JAIL_NAME}" mysqladmin reload
   iocage exec "${JAIL_NAME}" cp -f /mnt/includes/my.cnf /root/.my.cnf
   iocage exec "${JAIL_NAME}" sed -i '' "s|mypassword|${DB_ROOT_PASSWORD}|" /root/.my.cnf


### PR DESCRIPTION
I've seen a few situations where the use of `UPDATE` would lead to the following error:
`mysqli_real_connect hy000/1045: access denied for user 'root'@'localhost' (using password: no)`

This should prevent that from happening.