### PR TITLE
Handle custom netmask for JAIL_IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ CERT_EMAIL="me@example.com"
 Many of the options are self-explanatory, and all should be adjusted to suit your needs, but only a few are mandatory.  The mandatory options are:
 
 * JAIL_IP is the IP address for your jail
+* JAIL_NETMASK is the netmask to use for JAIL_IP. Defaults to `24`.
 * DEFAULT_GW_IP is the address for your default gateway
 * POOL_PATH is the path for your data pool.
 * TIME_ZONE is the time zone of your location, in PHP notation--see the [PHP manual](http://php.net/manual/en/timezones.php) for a list of all valid time zones.

--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -16,6 +16,7 @@ fi
 
 # Initialize defaults
 JAIL_IP=""
+JAIL_NETMASK="24"
 JAIL_INTERFACES=""
 DEFAULT_GW_IP=""
 INTERFACE="vnet0"
@@ -71,6 +72,10 @@ fi
 # Check that necessary variables were set by nextcloud-config
 if [ -z "${JAIL_IP}" ]; then
   echo 'Configuration error: JAIL_IP must be set'
+  exit 1
+fi
+if [ -z "${JAIL_NETMASK}" ]; then
+  echo 'Configuration error: JAIL_NETMASK must be set'
   exit 1
 fi
 if [ -z "${JAIL_INTERFACES}" ]; then
@@ -193,7 +198,7 @@ cat <<__EOF__ >/tmp/pkg.json
 __EOF__
 
 # Create the jail and install previously listed packages
-if ! iocage create --name "${JAIL_NAME}" -p /tmp/pkg.json -r "${RELEASE}" interfaces="${JAIL_INTERFACES}" ip4_addr="${INTERFACE}|${JAIL_IP}/24" defaultrouter="${DEFAULT_GW_IP}" boot="on" host_hostname="${JAIL_NAME}" vnet="${VNET}"
+if ! iocage create --name "${JAIL_NAME}" -p /tmp/pkg.json -r "${RELEASE}" interfaces="${JAIL_INTERFACES}" ip4_addr="${INTERFACE}|${JAIL_IP}/${JAIL_NETMASK}" defaultrouter="${DEFAULT_GW_IP}" boot="on" host_hostname="${JAIL_NAME}" vnet="${VNET}"
 then
 	echo "Failed to create jail"
 	exit 1


### PR DESCRIPTION
It was recently necessary for me to set a `/16` for a `JAIL_IP`. This makes that possible.

Default behavior is maintained. New option is documented.