### PR TITLE
Improvement to redis socket security

### DIFF
--- a/includes/redis.conf
+++ b/includes/redis.conf
@@ -98,8 +98,8 @@ tcp-backlog 511
 # incoming connections. There is no default, so Redis will not listen
 # on a unix socket when not specified.
 #
-unixsocket /tmp/redis.sock
-unixsocketperm 777
+unixsocket /var/run/redis/redis.sock
+unixsocketperm 770
 
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout 0

--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -419,7 +419,7 @@ iocage exec "${JAIL_NAME}" su -m www -c 'php /usr/local/www/nextcloud/occ config
 iocage exec "${JAIL_NAME}" su -m www -c 'php /usr/local/www/nextcloud/occ config:system:set loglevel --value="2"'
 iocage exec "${JAIL_NAME}" su -m www -c 'php /usr/local/www/nextcloud/occ config:system:set logrotate_size --value="104847600"'
 iocage exec "${JAIL_NAME}" su -m www -c 'php /usr/local/www/nextcloud/occ config:system:set memcache.local --value="\OC\Memcache\APCu"'
-iocage exec "${JAIL_NAME}" su -m www -c 'php /usr/local/www/nextcloud/occ config:system:set redis host --value="/tmp/redis.sock"'
+iocage exec "${JAIL_NAME}" su -m www -c 'php /usr/local/www/nextcloud/occ config:system:set redis host --value="/var/run/redis/redis.sock"'
 iocage exec "${JAIL_NAME}" su -m www -c 'php /usr/local/www/nextcloud/occ config:system:set redis port --value=0 --type=integer'
 iocage exec "${JAIL_NAME}" su -m www -c 'php /usr/local/www/nextcloud/occ config:system:set memcache.locking --value="\OC\Memcache\Redis"'
 iocage exec "${JAIL_NAME}" su -m www -c "php /usr/local/www/nextcloud/occ config:system:set overwritehost --value=\"${HOST_NAME}\""
@@ -441,6 +441,9 @@ fi
 
 iocage exec "${JAIL_NAME}" su -m www -c 'php -f /usr/local/www/nextcloud/cron.php'
 iocage exec "${JAIL_NAME}" crontab -u www /mnt/includes/www-crontab
+
+# Add the www user to the redis group to allow it to access the socket
+iocage exec "${JAIL_NAME}" pw usermod www -G redis
 
 # Don't need /mnt/includes any more, so unmount it
 iocage fstab -r "${JAIL_NAME}" "${INCLUDES_PATH}" /mnt/includes nullfs rw 0 0


### PR DESCRIPTION
Currently, permissions for the redis socket are 777; access for everyone. This presents a security vulnerability that allows any user to read cached data. I've modified the permissions to 770. To facilitate this I moved the socket to `/var/run/redis`, which is a directory with ownership `redis:redis`. This solves the problem of having it in `/tmp`, where the ownership of the socket is `redis:wheel`. The change in directory permissions allows other users to be added to the `redis` group without unnecessarily providing a user with the permissions of `wheel`.

Namely, it allows the `www` user to be added to the `redis` group, which allows the removal of any permissions to "other" users.

If you have any feedback let me know :)