### PR TITLE
Direct stdout and stderr to /var/log/caddy.log.

### DIFF
--- a/includes/caddy
+++ b/includes/caddy
@@ -14,8 +14,6 @@
 # caddy_config (string): Optional full path for caddy config file
 # caddy_adapter (string):  Optional adapter type if the configuration is not in caddyfile format
 # caddy_extra_flags (string):  Optional flags passed to caddy start
-# caddy_logfile (string)"     Set to "/var/log/caddy.log" by default.
-#                             Defines where the process log file is written, this is not a web access log
 
 . /etc/rc.subr
 
@@ -30,18 +28,23 @@ load_rc_config $name
 : ${caddy_config:="/usr/local/etc/Caddyfile"}
 : ${caddy_adapter:=caddyfile}
 : ${caddy_extra_flags:=""}
-: ${caddy_logfile="/var/log/caddy.log"}
 
 command="/usr/local/bin/${name}"
 caddy_flags="--config ${caddy_config} --adapter ${caddy_adapter}"
-pidfile=/var/run/${name}.pid
+pidfile="/var/run/${name}.pid"
+logfile="/var/log/${name}.log"
 
 # Extra Commands
 extra_commands="validate reload"
-start_cmd="${command} start ${caddy_flags} ${caddy_extra_flags} --pidfile /var/run/${name}.pid >> ${caddy_logfile} 2>&1"
+start_cmd="${name}_start""
 validate_cmd="${command} validate ${caddy_flags}"
 reload_cmd="${command} reload ${caddy_flags}"
 stop_cmd="${command} stop"
 restart_cmd="${stop_cmd} && ${start_cmd}"
+
+caddy_start()
+{
+  ${command} start --config ${caddy_config} --adapter ${caddy_adapter} --pidfile ${pidfile} >> ${logfile} 2>&1
+}
 
 run_rc_command "$1"


### PR DESCRIPTION
More information at https://caddy.community/t/how-to-use-the-expanded-form-of-php-fastcgi/9228/1