### PR TITLE
Useful tweaks

### DIFF
--- a/includes/caddy
+++ b/includes/caddy
@@ -36,12 +36,12 @@ command="/usr/local/bin/${name}"
 caddy_flags="--config ${caddy_config} --adapter ${caddy_adapter}"
 pidfile="/var/run/${name}.pid"
 
+required_files="${caddy_config} ${command}"
+
 # Extra Commands
 extra_commands="validate reload"
 start_cmd="${command} start ${caddy_flags} ${caddy_extra_flags} --pidfile ${pidfile} >> ${caddy_logfile} 2>&1"
 validate_cmd="${command} validate ${caddy_flags}"
 reload_cmd="${command} reload ${caddy_flags}"
-stop_cmd="${command} stop"
-restart_cmd="${stop_cmd} && ${start_cmd}"
 
 run_rc_command "$1"


### PR DESCRIPTION
required files - I recommend a check for the existence of the Caddy binary and Caddyfile. This is a built-in check. With the check, a service caddy start will alert the user if either of these files is missing; without it, no cue is provided.
Superfluous command definitions - stop and restart, as well as many other commands such as status and extracommands, are automatically supported as defined in rc(8). See https://www.freebsd.org/cgi/man.cgi?query=rc&sektion=8&manpath=freebsd-release-ports. There doesn't appear to be any value in including these command definitions. If anything, it makes things a little more ambiguous as it detracts from the commands that must be defined or altered i.e. start, validate and reload.