### PR TITLE
Caddyfile tweaks

### DIFF
--- a/includes/Caddyfile
+++ b/includes/Caddyfile
@@ -13,13 +13,11 @@ yourhostnamehere {
 		format single_field common_log
 	}
 
-	php_fastcgi 127.0.0.1:9000 {
-		env front_controller_active true
-	}
+	php_fastcgi 127.0.0.1:9000
 
 	header {
 		# enable HSTS
-		# Strict-Transport-Security max-age=31536000;
+		# Strict-Transport-Security max-age=15552000;
 	}
 
 	redir /.well-known/carddav /remote.php/dav 301


### PR DESCRIPTION
1. max-age updated for the Nextcloud security warning to disappear.
2. The php_fastcgi env switch did not get any endorsement in https://caddy.community/t/help-to-migrate-caddyfile-v1-to-v2-for-nextcloud/7647/30. It did not form part of the base solution. I tested Caddyfile without it and did not detect any visible difference. You may wish to consider removing it.