### PR TITLE
Update nexcloud version and convenience changes; Requires testing

### DIFF
--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -37,6 +37,7 @@ NO_CERT=0
 DL_FLAGS=""
 DNS_SETTING=""
 CONFIG_NAME="nextcloud-config"
+NEXTCLOUD_VERSION="20"
 #RELEASE="12.0-RELEASE"
 
 # Check for nextcloud-config and set configuration
@@ -295,7 +296,7 @@ fi
 #
 #####
 
-FILE="latest-19.tar.bz2"
+FILE="latest-${NEXTCLOUD_VERSION}.tar.bz2"
 if ! iocage exec "${JAIL_NAME}" fetch -o /tmp https://download.nextcloud.com/server/releases/"${FILE}" https://download.nextcloud.com/server/releases/"${FILE}".asc https://nextcloud.com/nextcloud.asc
 then
 	echo "Failed to download Nextcloud"


### PR DESCRIPTION
Update Nextcloud version to 20 by adding `NEXTCLOUD_VERSION` variable to `#initialize defaults` section. This simplifies required changes on upcoming nexcloud updates and also provides the possibility to install custom versions when wanted.

These changes are currently not tested, but they will until this weekend, as soon as I get time to re-setup nextcloud on my FreeNAS instance.