### PR TITLE
Fix installation using postgres

### DIFF
--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -241,10 +241,10 @@ iocage fstab -a "${JAIL_NAME}" "${CONFIG_PATH}" /usr/local/www/nextcloud/config 
 iocage fstab -a "${JAIL_NAME}" "${THEMES_PATH}" /usr/local/www/nextcloud/themes nullfs rw 0 0
 if [ "${DATABASE}" = "mariadb" ]; then
   mkdir -p "${JAILS_MOUNT}"/jails/${JAIL_NAME}/root/var/db/mysql
-  iocage fstab -a "${JAIL_NAME}" "${DB_PATH}/mariadb"  /var/db/mysql  nullfs  rw  0  0
+  iocage fstab -a "${JAIL_NAME}" "${DB_PATH}"/"${DATABASE}" /var/db/mysql  nullfs  rw  0  0
 elif [ "${DATABASE}" = "pgsql" ]; then
   mkdir -p "${JAILS_MOUNT}"/jails/${JAIL_NAME}/root/var/db/postgres
-  iocage fstab -a "${JAIL_NAME}" "${DB_PATH}"/"${DATABASE}"  /var/db/postgres  nullfs  rw  0  0
+  iocage fstab -a "${JAIL_NAME}" "${DB_PATH}"/"${DATABASE}" /var/db/postgres  nullfs  rw  0  0
 fi
 iocage fstab -a "${JAIL_NAME}" "${INCLUDES_PATH}" /mnt/includes nullfs rw 0 0
 iocage exec "${JAIL_NAME}" chown -R www:www /mnt/files
@@ -258,7 +258,7 @@ iocage exec "${JAIL_NAME}" chmod -R 770 /mnt/files
 #####
 
 if [ "${DATABASE}" = "mariadb" ]; then
-	iocage exec "${JAIL_NAME}" pkg install -qy mariadb103-server php74-pdo_mysql php74-mysqli
+  iocage exec "${JAIL_NAME}" pkg install -qy mariadb103-server php74-pdo_mysql php74-mysqli
 elif [ "${DATABASE}" = "pgsql" ]; then
   iocage exec "${JAIL_NAME}" pkg install -qy postgresql12-server php74-pgsql php74-pdo_pgsql
 fi

--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -406,7 +406,7 @@ elif [ "${DATABASE}" = "pgsql" ]; then
   iocage exec "${JAIL_NAME}" chmod 600 /root/.pgpass
   iocage exec "${JAIL_NAME}" chown postgres /var/db/postgres/
   iocage exec "${JAIL_NAME}" /usr/local/etc/rc.d/postgresql initdb
-  iocage exec "${JAIL_NAME}" su -m postgres -c '/usr/local/bin/pg_ctl -D /var/db/postgres/data10 start'
+  iocage exec "${JAIL_NAME}" su -m postgres -c '/usr/local/bin/pg_ctl -D /var/db/postgres/data12 start'
   iocage exec "${JAIL_NAME}" sed -i '' "s|mypassword|${DB_ROOT_PASSWORD}|" /root/.pgpass
   iocage exec "${JAIL_NAME}" psql -U postgres -c "CREATE DATABASE nextcloud;"
   iocage exec "${JAIL_NAME}" psql -U postgres -c "CREATE USER nextcloud WITH ENCRYPTED PASSWORD '${DB_PASSWORD}';"

--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -244,7 +244,7 @@ if [ "${DATABASE}" = "mariadb" ]; then
   iocage fstab -a "${JAIL_NAME}" "${DB_PATH}/mariadb"  /var/db/mysql  nullfs  rw  0  0
 elif [ "${DATABASE}" = "pgsql" ]; then
   mkdir -p "${JAILS_MOUNT}"/jails/${JAIL_NAME}/root/var/db/postgres
-  iocage fstab -a "${JAIL_NAME}" "${DB_PATH}/psql"  /var/db/postgres  nullfs  rw  0  0
+  iocage fstab -a "${JAIL_NAME}" "${DB_PATH}"/"${DATABASE}"  /var/db/postgres  nullfs  rw  0  0
 fi
 iocage fstab -a "${JAIL_NAME}" "${INCLUDES_PATH}" /mnt/includes nullfs rw 0 0
 iocage exec "${JAIL_NAME}" chown -R www:www /mnt/files
@@ -260,7 +260,7 @@ iocage exec "${JAIL_NAME}" chmod -R 770 /mnt/files
 if [ "${DATABASE}" = "mariadb" ]; then
 	iocage exec "${JAIL_NAME}" pkg install -qy mariadb103-server php74-pdo_mysql php74-mysqli
 elif [ "${DATABASE}" = "pgsql" ]; then
-  iocage exec "${JAIL_NAME}" pkg install -qy postgresql10-server php74-pgsql php74-pdo_pgsql
+  iocage exec "${JAIL_NAME}" pkg install -qy postgresql12-server php74-pgsql php74-pdo_pgsql
 fi
 
 # Ports not currently used, Commented out for future use


### PR DESCRIPTION
Fix path for database not beeing linked properly by `iocage fstab`, which resulted in a database stored inside the jail.
Fix postgres version to match php74 client required one (postgresql12), which made the script fail due to unmet dependencies. It might be woth to investigate a "proper" fix for this, as any php upgrade might cause incompatibilites again. The postgres version could maybe be inferred somehow from the php packages?

EDIT: This is a work in progress as there seem to appear further problems down the line. Still investigating.