### PR TITLE
update xcaddy build command

### DIFF
--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -267,14 +267,14 @@ fi
 #iocage exec "${JAIL_NAME}" "if [ -z /usr/ports ]; then portsnap fetch extract; else portsnap auto; fi"
 
 # Build xcaddy, use it to build Caddy
-if ! iocage exec "${JAIL_NAME}" "go get -u github.com/caddyserver/xcaddy/cmd/xcaddy"
+if ! iocage exec "${JAIL_NAME}" "go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest"
 then
   echo "Failed to get xcaddy, terminating."
   exit 1
 fi
-if ! iocage exec "${JAIL_NAME}" go build -o /usr/local/bin/xcaddy github.com/caddyserver/xcaddy/cmd/xcaddy
+if ! iocage exec "${JAIL_NAME}" cp /root/go/bin/xcaddy /usr/local/bin/xcaddy
 then
-  echo "Failed to build xcaddy, terminating."
+  echo "Failed to move xcaddy to path, terminating."
   exit 1
 fi
 if [ ${DNS_CERT} -eq 1 ]; then


### PR DESCRIPTION
First, thank you very much for sharing this work.

xcaddy recently changed their build instructions, see [here](https://github.com/caddyserver/xcaddy/commit/83655481bffa4ff2a6a2c811ab0d95478ef084ef), so the script failed for me on a fresh install on 12.2-RELEASE. With the new build command the binary is placed in $GOPATH/bin, which is /root/go/bin in this case, so I simply copy it to /usr/local/bin to add to path.

please consider these changes.