### PR TITLE
Enable APCu cli to prevent PHP Fatal error

### DIFF
--- a/includes/php.ini
+++ b/includes/php.ini
@@ -373,6 +373,11 @@ zend.enable_gc = On
 ; http://php.net/expose-php
 expose_php = On
 
+; Enable the apc cli to prevent memory error, see link below for more info
+; https://help.nextcloud.com/t/solved-occ-command-php-fatal-error-allowed-memory-size-of-xxx-bytes-exhausted/108521/28
+[apcu]
+apc.enable_cli=1
+
 ;;;;;;;;;;;;;;;;;;;
 ; Resource Limits ;
 ;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Please consider adding this to the default php.ini configuration. There is no default section for APCu, so I added it under Miscellaneous comment block.

Without this enabled, the nextcloud cron job fails.

See also: https://help.nextcloud.com/t/solved-occ-command-php-fatal-error-allowed-memory-size-of-xxx-bytes-exhausted/108521/17

See also: https://www.php.net/manual/en/apcu.configuration.php