### PR TITLE
Update nextcloud-jail.sh because of a 500 server error on reinstall.

### DIFF
--- a/nextcloud-jail.sh
+++ b/nextcloud-jail.sh
@@ -440,6 +440,10 @@ iocage restart "${JAIL_NAME}"
 iocage exec "${JAIL_NAME}" touch /var/log/nextcloud.log
 iocage exec "${JAIL_NAME}" chown www /var/log/nextcloud.log
 
+# Add the www user to the redis group to allow it to access the socket
+iocage exec "${JAIL_NAME}" pw usermod www -G redis
+iocage exec "${JAIL_NAME}" chmod 777 /var/run/redis/redis.sock
+
 # Skip generation of config and database for reinstall (this already exists when doing a reinstall)
 if [ "${REINSTALL}" == "true" ]; then
 	echo "Reinstall detected, skipping generation of new config and database"
@@ -478,10 +482,6 @@ fi
 iocage exec "${JAIL_NAME}" echo "${DB_NAME} root password is ${DB_ROOT_PASSWORD}" > /root/${JAIL_NAME}_db_password.txt
 iocage exec "${JAIL_NAME}" echo "Nextcloud database password is ${DB_PASSWORD}" >> /root/${JAIL_NAME}_db_password.txt
 iocage exec "${JAIL_NAME}" echo "Nextcloud Administrator password is ${ADMIN_PASSWORD}" >> /root/${JAIL_NAME}_db_password.txt
-
-# Add the www user to the redis group to allow it to access the socket
-iocage exec "${JAIL_NAME}" pw usermod www -G redis
-iocage exec "${JAIL_NAME}" chmod 777 /var/run/redis/redis.sock
 
 # Create Nextcloud log directory
 iocage exec "${JAIL_NAME}" mkdir -p /var/log/nextcloud/


### PR DESCRIPTION
Moved line 482-484 to the point right before it detects a reinstall to ensure redis functionality. 

Tested with a NO_CERT variant of the script reinstall, and it worked fine without errors.

Original script gives a 500 server error when doing a reinstall.